### PR TITLE
Add new learnings from 2024-10-28

### DIFF
--- a/pro-git/chapter-02/README.md
+++ b/pro-git/chapter-02/README.md
@@ -1,152 +1,22 @@
 # Chapter 2: Git Basics
 
-## Lifecycle of the Status of a File
+## Table of Contents
 
-```mermaid
-sequenceDiagram
-    participant utrack as Untracked
-    participant umod as Unmodified
-    participant mod as Modified
-    participant stage as Staged
-
-    utrack->>stage: Add the file
-    umod->>mod: Edit the file
-    mod->>stage:Stage the file
-    umod->>utrack:Remove the file
-    stage->>umod:Commit
-```
-
-## More on the `git status` Command
-
-- `git status`: Show the status of changes as untracked, modified, or staged.
-
-    ```shell
-    git status
-    ```
-
-    ```shell
-    On branch 2024-10-21_pro-git
-    Changes not staged for commit:
-    (use "git add <file>..." to update what will be committed)
-    (use "git restore <file>..." to discard changes in working directory)
-            modified:   README.md
-            modified:   pro-git/chapter-01/README.md
-
-    Untracked files:
-    (use "git add <file>..." to include in what will be committed)
-            pro-git/chapter-02/
-
-    no changes added to commit (use "git add" and/or "git commit -a")
-    ```
-
-- Shorter `git status`:
-
-    ```shell
-    git status --short
-    ```
-
-    ```shell
-     M README.md
-     M pro-git/chapter-01/README.md
-    ?? pro-git/chapter-02/
-    ```
-
-  - the first column represents the status of the staging area[^1]
-  - the second column represents the status of the working directory[^1]
-
-## Ignoring Files
-
-Rules of `.gitignore` files:
-
-- Blank lines or lines starting with `#` are ignored.
-- Standard [glob patterns](#glob-patterns) work, and will be applied recursively throughout the entire working directory (e.g. `*.log`).
-- You can start patterns with a forward slash (`/`) to avoid recursivity (e.g. `/*.log`).
-- You can end patterns with a forward slash (`/`) to specify a directory (e.g. `log/`).
-- You can negate a pattern by starting it with an exclamation point (`!`).
-
-### Glob patterns
-
-Glob patterns are regex[^2] for shell environments. Here are some examples:
-
-- `*`: matches zero or more characters
-- `[abc]`: matches any of the characters a, b, or c
-- `?`: matches a single character
-- brackets enclosing characters separated by a hyphen (`-`) represent a range (e.g. `[1-5]` matches any digit from 1 to 5)
-- two asterisks (`**`) represent any number of directories (e.g. `a/**/z` matches `a/z`, `a/b/z`, `a/b/c/z`, etc.)
-
-### Example `.gitignore` file[^3]
-
-```gitignore
-# ignore all .a files
-*.a
-
-# but do track lib.a, even though you're ignoring .a files above
-!lib.a
-
-# only ignore the TODO file in the current directory, not subdir/TODO
-/TODO
-
-# ignore all files in any directory named build
-build/
-
-# ignore doc/notes.txt, but not doc/server/arch.txt
-doc/*.txt
-
-# ignore all .pdf file in the doc/ directory and any of its subdirectories
-doc/**/*.pdf
-```
-
-## Compare Changes Made with `git diff`
-
-Use `git status` as a primer for this:
-
-```shell
-git status
-```
-
-```shell
-On branch 2024-10-21_pro-git
-Changes not staged for commit:
-  (use "git add <file>..." to update what will be committed)
-  (use "git restore <file>..." to discard changes in working directory)
-        modified:   README.md
-        modified:   pro-git/chapter-01/README.md
-
-Untracked files:
-  (use "git add <file>..." to include in what will be committed)
-        pro-git/chapter-02/
-
-no changes added to commit (use "git add" and/or "git commit -a")
-```
-
-Let's check what was changed in `README.md`:
-
-```shell
-git diff README.md
-```
-
-```shell
-diff --git a/README.md b/README.md
-index 74889a8..b4e04ff 100644
---- a/README.md
-+++ b/README.md
-@@ -6,4 +6,4 @@ Contains a collection of READMEs for the various areas of my learning. Some exer
- 
- - [GNU `grep` and `ripgrep`](gnu-grep/)
- - [LDAP](ldap/)
--- [Pro Git](pro-git/)
-\ No newline at end of file
-+- [Pro Git](pro-git/)
-```
-
-## Removing Files from the Staging Area, but Retaining in the Working Directory
-
-```shell
-git rm --cached FILENAME
-```
-
-This way, the file will no longer be tracked, but you want to retain in the working directory — perhaps to be added to the `.gitignore` file.
-
-[^1]: [See Chapter 01](../chapter-01/README.md) for more information on the staging area and the working directory.
-[^2]: Regular expressions
-[^3]: [Examples from GitHub](https://github.com/github/gitignore)
+- [Lifecycle of the Status of a File](lifecycle.md)
+- [More on the `git status` Command](status.md)
+- [Ignoring Files](ignoring-files.md)
+  - [Glob Patterns](ignoring-files.md#glob-patterns)
+  - [Example `.gitignore` file](ignoring-files.md#example-gitignore-file)
+- [Compare Changes Made with `git diff`](diff-rm.md#compare-changes-made-with-git-diff)
+- [Removing Files from the Staging Area, but Retaining in the Working Directory](diff-rm.md#removing-files-from-the-staging-area-but-retaining-in-the-working-directory)
+- [Checking Commit History](commit-history.md#checking-commit-history)
+  - [`git log`](commit-history.md#git-log)
+  - [`git log --patch -<n>`](commit-history.md#git-log---patch--n)
+  - [`git log --stat`](commit-history.md#git-log---stat)
+  - [`git log --pretty=<option>`](commit-history.md#git-log---prettyoption)
+- [Combining the `--pretty` option with the `--graph` option](commit-history.md#combining-the---pretty-option-with-the---graph-option)
+  - [Common options to `git-log`](commit-history.md#common-options-to-git-log)
+- [Limiting Log Output](log-output.md)
+  - [`git log --since=<n>`](log-output.md#git-log---sincen)
+  - [`git log -S <string>`](log-output.md#git-log--s-string)
+  - [Common options to limit output to `git-log`](log-output.md#common-options-to-limit-output-to-git-log)

--- a/pro-git/chapter-02/commit-history.md
+++ b/pro-git/chapter-02/commit-history.md
@@ -1,0 +1,164 @@
+## Checking Commit History
+
+> [!TIP]
+> More options for `git log` can be found here [^1].
+
+### `git log`
+
+Show the commit history:
+
+```shell
+commit ca82a6dff817ec66f44342007202690a93763949 (HEAD -> master, origin/master, origin/HEAD)
+Author: Scott Chacon <schacon@gmail.com>
+Date:   Mon Mar 17 21:52:11 2008 -0700
+
+    changed the verison number
+
+commit 085bb3bcb608e1e8451d4b2432f8ecbe6306e7e7
+Author: Scott Chacon <schacon@gmail.com>
+Date:   Sat Mar 15 16:40:33 2008 -0700
+
+    removed unnecessary test code
+
+commit a11bef06a3f659402fe7563abf99ad00de2209e6
+Author: Scott Chacon <schacon@gmail.com>
+Date:   Sat Mar 15 10:31:28 2008 -0700
+
+    first commit
+```
+
+### `git log --patch -<n>`
+
+Show the commit history with the diff of each commit (with `<n>` being the last `n` entries to show):
+
+```shell
+commit ca82a6dff817ec66f44342007202690a93763949 (HEAD -> master, origin/master, origin/HEAD)
+Author: Scott Chacon <schacon@gmail.com>
+Date:   Mon Mar 17 21:52:11 2008 -0700
+
+    changed the verison number
+
+diff --git a/Rakefile b/Rakefile
+index a874b73..8f94139 100644
+--- a/Rakefile
++++ b/Rakefile
+@@ -5,7 +5,7 @@ require 'rake/gempackagetask'
+ spec = Gem::Specification.new do |s|
+     s.platform  =   Gem::Platform::RUBY
+     s.name      =   "simplegit"
+-    s.version   =   "0.1.0"
++    s.version   =   "0.1.1"
+     s.author    =   "Scott Chacon"
+     s.email     =   "schacon@gmail.com"
+     s.summary   =   "A simple gem for using Git in Ruby code."
+
+commit 085bb3bcb608e1e8451d4b2432f8ecbe6306e7e7
+Author: Scott Chacon <schacon@gmail.com>
+Date:   Sat Mar 15 16:40:33 2008 -0700
+
+    removed unnecessary test code
+
+diff --git a/lib/simplegit.rb b/lib/simplegit.rb
+index a0a60ae..47c6340 100644
+--- a/lib/simplegit.rb
++++ b/lib/simplegit.rb
+@@ -18,8 +18,3 @@ class SimpleGit
+     end
+
+ end
+-
+-if $0 == __FILE__
+-  git = SimpleGit.new
+-  puts git.show
+-end
+```
+
+### `git log --stat`
+
+Show the commit history with the number of insertions and deletions in each commit:
+
+```shell
+commit ca82a6dff817ec66f44342007202690a93763949 (HEAD -> master, origin/master, origin/HEAD)
+Author: Scott Chacon <schacon@gmail.com>
+Date:   Mon Mar 17 21:52:11 2008 -0700
+
+    changed the verison number
+
+ Rakefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+commit 085bb3bcb608e1e8451d4b2432f8ecbe6306e7e7
+Author: Scott Chacon <schacon@gmail.com>
+Date:   Sat Mar 15 16:40:33 2008 -0700
+
+    removed unnecessary test code
+
+ lib/simplegit.rb | 5 -----
+ 1 file changed, 5 deletions(-)
+
+commit a11bef06a3f659402fe7563abf99ad00de2209e6
+Author: Scott Chacon <schacon@gmail.com>
+Date:   Sat Mar 15 10:31:28 2008 -0700
+
+    first commit
+
+ README           |  6 ++++++
+ Rakefile         | 23 +++++++++++++++++++++++
+ lib/simplegit.rb | 25 +++++++++++++++++++++++++
+ 3 files changed, 54 insertions(+)
+```
+
+### `git log --pretty=<option>`
+
+Show the commit history in one line. Options include:
+
+- `oneline`: show the commit hash and the commit message in one line
+
+    ```shell
+    git log --pretty=oneline
+
+    ca82a6dff817ec66f44342007202690a93763949 (HEAD -> master, origin/master, origin/HEAD) changed the verison number
+    085bb3bcb608e1e8451d4b2432f8ecbe6306e7e7 removed unnecessary test code
+    a11bef06a3f659402fe7563abf99ad00de2209e6 first commit
+    ```
+
+- `format:"%h - %an, %ar : %s"`: show the abbreviated commit hash (`%h`), the author name (`%an`), the author date, relative (`%ar`), and the subject (`%s`) of the commit
+
+    ```shell
+    git log git log --pretty=format:"%h - %an, %ad : %s"
+
+    ca82a6d - Scott Chacon, 7 years ago : changed the verison number
+    085bb3b - Scott Chacon, 7 years ago : removed unnecessary test code
+    a11bef0 - Scott Chacon, 7 years ago : first commit
+    ```
+
+## Combining the `--pretty` option with the `--graph` option
+
+Combining both the `--pretty` and `--graph` options will show the commit history in a graph format. Below is an example of the commit history of this repository:
+
+```shell
+git log --pretty=format:"%h %s" --graph
+
+* 0931157 2024-10-21: Pro Git Learnings (#3)
+*   9540054 Merge branch 'main' into development
+|\  
+| * cbf9b53 First PR for LDAP (#2)
+* | ed64291 First PR for `gnu grep` (#1)
+|/  
+* fe49b8b Initial commit
+```
+
+### Common options to `git-log`
+
+- `-p` or `--patch`: Show the patch introduced with each commit.
+- `--stat`: Show statistics for files modified in each commit.
+- `--shortstat`: Show only the changed/insertions/deletions line from the `--stat` option.
+- `--name-only`: Show the list of files modified after the commit information.
+- `--name-status`: Show the list of files modified after the commit information, indicating the status of the changes.
+- `--abbrev-commit`: Show only the first few characters of the SHA-1 checksum instead of all 40.
+- `--relative-date`: Display the date in a relative format (e.g. "2 weeks ago") instead of using the full date format.
+- `--graph`: Show an ASCII graph of the branch and merge history beside the log output.
+- `--pretty`: Show commits in an alternate format. Options include `oneline`, `short`, `full`, `fuller`, `format`, and `email`.
+- `--oneline`: Shorthand for `--pretty=oneline --abbrev-commit` used together.
+
+[^1]: [Manual for `git-log`](https://git-scm.com/docs/git-log)

--- a/pro-git/chapter-02/diff-rm.md
+++ b/pro-git/chapter-02/diff-rm.md
@@ -1,0 +1,50 @@
+## Compare Changes Made with `git diff`
+
+Use `git status` as a primer for this:
+
+```shell
+git status
+```
+
+```shell
+On branch 2024-10-21_pro-git
+Changes not staged for commit:
+  (use "git add <file>..." to update what will be committed)
+  (use "git restore <file>..." to discard changes in working directory)
+        modified:   README.md
+        modified:   pro-git/chapter-01/README.md
+
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+        pro-git/chapter-02/
+
+no changes added to commit (use "git add" and/or "git commit -a")
+```
+
+Let's check what was changed in `README.md`:
+
+```shell
+git diff README.md
+```
+
+```shell
+diff --git a/README.md b/README.md
+index 74889a8..b4e04ff 100644
+--- a/README.md
++++ b/README.md
+@@ -6,4 +6,4 @@ Contains a collection of READMEs for the various areas of my learning. Some exer
+ 
+ - [GNU `grep` and `ripgrep`](gnu-grep/)
+ - [LDAP](ldap/)
+-- [Pro Git](pro-git/)
+\ No newline at end of file
++- [Pro Git](pro-git/)
+```
+
+## Removing Files from the Staging Area, but Retaining in the Working Directory
+
+```shell
+git rm --cached FILENAME
+```
+
+This way, the file will no longer be tracked, but you want to retain in the working directory — perhaps to be added to the `.gitignore` file.

--- a/pro-git/chapter-02/ignoring-files.md
+++ b/pro-git/chapter-02/ignoring-files.md
@@ -1,0 +1,44 @@
+## Ignoring Files
+
+Rules of `.gitignore` files:
+
+- Blank lines or lines starting with `#` are ignored.
+- Standard [glob patterns](#glob-patterns) work, and will be applied recursively throughout the entire working directory (e.g. `*.log`).
+- You can start patterns with a forward slash (`/`) to avoid recursivity (e.g. `/*.log`).
+- You can end patterns with a forward slash (`/`) to specify a directory (e.g. `log/`).
+- You can negate a pattern by starting it with an exclamation point (`!`).
+
+### Glob patterns
+
+Glob patterns are regex[^1] for shell environments. Here are some examples:
+
+- `*`: matches zero or more characters
+- `[abc]`: matches any of the characters a, b, or c
+- `?`: matches a single character
+- brackets enclosing characters separated by a hyphen (`-`) represent a range (e.g. `[1-5]` matches any digit from 1 to 5)
+- two asterisks (`**`) represent any number of directories (e.g. `a/**/z` matches `a/z`, `a/b/z`, `a/b/c/z`, etc.)
+
+### Example `.gitignore` file[^2]
+
+```gitignore
+# ignore all .a files
+*.a
+
+# but do track lib.a, even though you're ignoring .a files above
+!lib.a
+
+# only ignore the TODO file in the current directory, not subdir/TODO
+/TODO
+
+# ignore all files in any directory named build
+build/
+
+# ignore doc/notes.txt, but not doc/server/arch.txt
+doc/*.txt
+
+# ignore all .pdf file in the doc/ directory and any of its subdirectories
+doc/**/*.pdf
+```
+
+[^1]: Regular expressions
+[^2]: [Examples from GitHub](https://github.com/github/gitignore)

--- a/pro-git/chapter-02/lifecycle.md
+++ b/pro-git/chapter-02/lifecycle.md
@@ -1,0 +1,15 @@
+## Lifecycle of the Status of a File
+
+```mermaid
+sequenceDiagram
+    participant utrack as Untracked
+    participant umod as Unmodified
+    participant mod as Modified
+    participant stage as Staged
+
+    utrack->>stage: Add the file
+    umod->>mod: Edit the file
+    mod->>stage:Stage the file
+    umod->>utrack:Remove the file
+    stage->>umod:Commit
+```

--- a/pro-git/chapter-02/log-output.md
+++ b/pro-git/chapter-02/log-output.md
@@ -1,0 +1,89 @@
+## Limiting Log Output
+
+> [!TIP]
+> More options for `git log` can be found here [^4].
+
+### `git log --since=<n>`
+
+Show the commit history since a specific `<n>` period.:
+
+```shell
+git log --since=2.weeks
+
+commit 093115704ed39d8544b42cb0f040da6e96b9f1af (HEAD -> 2024-10-28_pro-git, origin/development, development)
+Author: Justin Alex Paramanandan <1155821+jusuchin85@users.noreply.github.com>
+Date:   Mon Oct 21 10:59:09 2024 +1100
+
+    2024-10-21: Pro Git Learnings (#3)
+    
+    * Chapter 01
+    * Chapter 02
+
+commit 9540054165b7e2a56d7fe18f5e95216012da9f27
+Merge: ed64291 cbf9b53
+Author: Justin Alex Paramanandan <1155821+jusuchin85@users.noreply.github.com>
+Date:   Mon Oct 21 10:04:12 2024 +1100
+
+    Merge branch 'main' into development
+
+commit cbf9b53ae48e3f8cf8e54432e33b64bd59383b82 (origin/main, origin/HEAD, main)
+Author: Justin Alex Paramanandan <1155821+jusuchin85@users.noreply.github.com>
+Date:   Mon Oct 21 10:00:33 2024 +1100
+
+    First PR for LDAP (#2)
+    
+    * Create LDAP directory
+        - renamed `commands` directory to `ldapsearch`
+        - added README for LDAP directory
+...
+```
+
+### `git log -S <string>`
+
+Show the commit history with the changes that include the `<string>`:
+
+```shell
+git log -S ldapsearch
+
+commit cbf9b53ae48e3f8cf8e54432e33b64bd59383b82 (origin/main, origin/HEAD, main)
+Author: Justin Alex Paramanandan <1155821+jusuchin85@users.noreply.github.com>
+Date:   Mon Oct 21 10:00:33 2024 +1100
+
+    First PR for LDAP (#2)
+    
+    * Create LDAP directory
+        - renamed `commands` directory to `ldapsearch`
+        - added README for LDAP directory
+```
+
+### Common options to limit output to `git-log`
+
+- `-<n>`: Show only the last `n` commits.
+- `--since`, `--after`: Limit the commits to those made after the specified date.
+- `--until`, `--before`: Limit the commits to those made before the specified date.
+- `--author`: Only show commits in which the author entry matches the specified string.
+- `--committer`: Only show commits in which the committer entry matches the specified string.
+- `-S`: Only show commits adding or removing the specified string.
+- `--grep`: Only show commits whose message matches the specified regular expression.
+
+For example, to see commits in the Git repository [^1] that:
+
+- were modified test files
+- committed by Junio C Hamano
+- committed in the month of October 2008
+- not merge commits
+
+```shell
+git log --pretty=format:"%h - %an, %ad : %s" --author="Junio C Hamano" --since="2008-10-01" --before="2008-11-01" --no-merges -- t/
+
+5610e3b031 - Junio C Hamano, Sun Oct 19 22:51:17 2008 -0700 : Fix testcase failure when extended attributes are in use
+acd3b9eca8 - Junio C Hamano, Fri Oct 17 15:44:39 2008 -0700 : Enhance hold_lock_file_for_{update,append}() API
+f5637549a7 - Junio C Hamano, Fri Oct 17 15:56:11 2008 -0700 : demonstrate breakage of detached checkout with symbolic link HEAD
+d1a43f2aa4 - Junio C Hamano, Wed Oct 15 16:00:06 2008 -0700 : reset --hard/read-tree --reset -u: remove unmerged new paths
+51a94af845 - Junio C Hamano, Thu Oct 16 23:37:44 2008 -0700 : Fix "checkout --track -b newbranch" on detached HEAD
+b0ad11ea16 - Junio C Hamano, Tue Oct 14 15:32:20 2008 -0700 : pull: allow "git pull origin $something:$current_branch" into an unborn branch
+```
+
+At time of writing, there are more than 75,000 commits in the Git source code history. This command shows the 6 commits that match the specified criteria.
+
+[^1]: [Git repository](https://github.com/git/git)

--- a/pro-git/chapter-02/status.md
+++ b/pro-git/chapter-02/status.md
@@ -1,0 +1,39 @@
+## More on the `git status` Command
+
+- `git status`: Show the status of changes as untracked, modified, or staged.
+
+    ```shell
+    git status
+    ```
+
+    ```shell
+    On branch 2024-10-21_pro-git
+    Changes not staged for commit:
+    (use "git add <file>..." to update what will be committed)
+    (use "git restore <file>..." to discard changes in working directory)
+            modified:   README.md
+            modified:   pro-git/chapter-01/README.md
+
+    Untracked files:
+    (use "git add <file>..." to include in what will be committed)
+            pro-git/chapter-02/
+
+    no changes added to commit (use "git add" and/or "git commit -a")
+    ```
+
+- Shorter `git status`:
+
+    ```shell
+    git status --short
+    ```
+
+    ```shell
+     M README.md
+     M pro-git/chapter-01/README.md
+    ?? pro-git/chapter-02/
+    ```
+
+  - the first column represents the status of the staging area[^1]
+  - the second column represents the status of the working directory[^1]
+
+[^1]: [See Chapter 01](../chapter-01/README.md) for more information on the staging area and the working directory.


### PR DESCRIPTION
This pull request reorganises the content in Chapter 2 of the Pro Git documentation by splitting it into separate files for better readability and maintainability. The changes include moving existing sections into new dedicated files and updating the table of contents to reflect these changes.

Content reorganisation:

* [`pro-git/chapter-02/README.md`](diffhunk://#diff-8b987545bd98059217de99165036a2942678d771390c8545da7438839195669bL3-R22): Replaced detailed content with a Table of Contents linking to new topic-specific markdown files.

New topic-specific files:

* [`pro-git/chapter-02/commit-history.md`](diffhunk://#diff-ace0cdb24379fcac659e591dc7bcba1233f5732ee9574a91cac9af6855d4f83bR1-R164): Added detailed instructions on checking commit history using various `git log` options.
* [`pro-git/chapter-02/diff-rm.md`](diffhunk://#diff-e6ce66976f188beaa4bc1192715c3c8f91f5eb89abb049f2a213fc6fbfe61613R1-R50): Added sections on comparing changes with `git diff` and removing files from the staging area.
* [`pro-git/chapter-02/ignoring-files.md`](diffhunk://#diff-8105f21a2efc5d2a2ebab89e648065a92b934a51167cbcc272ca4f4a33983e1dR1-R44): Added rules and examples for `.gitignore` files, including glob patterns.
* [`pro-git/chapter-02/lifecycle.md`](diffhunk://#diff-d41a3159a4fc7de933de2049091a6a0186f8ee927154418569d310b89601d0dfR1-R15): Added a mermaid diagram illustrating the lifecycle of the status of a file.
* [`pro-git/chapter-02/log-output.md`](diffhunk://#diff-ca5792bd41a6ce2b323c9e0c8892bbb653db4440deecdff2144c1bc0b8c24deeR1-R89): Added options to limit log output with `git log`.
* [`pro-git/chapter-02/status.md`](diffhunk://#diff-a4588bd40aa63134a47f31fb812fe9757f482321e0f8734cf47246185d38c411R1-R39): Added more details on the `git status` command and its shorter version.